### PR TITLE
Fix php object name

### DIFF
--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -39,7 +39,7 @@ use Touchbase\Core\Config\ConfigTrait;
 use Touchbase\Core\Config\Store as ConfigStore;
 use Touchbase\Core\Config\Provider\IniConfigProvider;
 
-class Client extends \Touchbase\Core\Object
+class Client extends \Touchbase\Core\BaseObject
 {
 	use ConfigTrait;
 

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -122,6 +122,14 @@ class Controller extends RequestHandler
 	public function request(){
 		return $this->request;
 	}
+    
+    /**
+	 *	Response
+	 *	@return \Touchbase\Control\HTTPResponse
+	 */
+	public function response(){
+		return $this->response;
+	}
 	
 	/**
 	 *	Handle Request

--- a/src/Control/HTTPHeaders.php
+++ b/src/Control/HTTPHeaders.php
@@ -31,7 +31,7 @@ namespace Touchbase\Control;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class HTTPHeaders extends \Touchbase\Core\Object
+class HTTPHeaders extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	@var array

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -34,7 +34,7 @@ use Touchbase\Security\Auth;
 use Touchbase\Core\Config\ConfigTrait;
 use Touchbase\Control\Exception\HTTPResponseException;
 
-class RequestHandler extends \Touchbase\Core\Object 
+class RequestHandler extends \Touchbase\Core\BaseObject 
 {
 	use ConfigTrait;
 
@@ -106,7 +106,7 @@ class RequestHandler extends \Touchbase\Core\Object
 						}
 						
 						if(!$this->hasMethod($action) || !$this->isEnabled() || !$this->application()->isEnabled()){
-                            return $this->throwHTTPError(404, "Action '$action' isn't available on class $this");
+							return $this->throwHTTPError(404, "Action '$action' isn't available on class $this");
 						}
 						
 						if(!$this->isAllowed() || !$this->application()->isAllowed() || !$this->checkAccessAction($action)){

--- a/src/Control/Router.php
+++ b/src/Control/Router.php
@@ -43,7 +43,7 @@ use Touchbase\Control\Exception\HTTPResponseException;
 use Touchbase\Core\Config\ConfigTrait;
 use Touchbase\Core\Config\Store as ConfigStore;
 
-class Router extends \Touchbase\Core\Object
+class Router extends \Touchbase\Core\BaseObject
 {
 	const ROUTE_HISTORY_KEY = "touchbase.key.route_history";
 	

--- a/src/Control/WebpageController.php
+++ b/src/Control/WebpageController.php
@@ -48,15 +48,7 @@ class WebpageController extends Controller
 	
 	/* Public Methods */
 	
-	/**
-	 *	Request
-	 *	@return \Touchbase\Control\HTTPRequest
-	 */
-	public function response(){
-		return $this->response;
-	}
-	
-	/**
+   	/**
 	 *	Handle Request
 	 *	@param HTTPRequest &$request
 	 *	@param HTTPResponse &$response
@@ -66,7 +58,8 @@ class WebpageController extends Controller
 			
 		//Pass through to Controller
 		try {
-			$response = new WebpageResponse($this);
+            $assets = ($response instanceof WebpageResponse)?$response->assets():[];
+			$response = new WebpageResponse($this, $assets);
 			
 			if($request->isPost()){
 				$validation = Validation::create();

--- a/src/Core/BaseObject.php
+++ b/src/Core/BaseObject.php
@@ -31,7 +31,7 @@ namespace Touchbase\Core;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-abstract class Object
+abstract class BaseObject
 {
 	use SynthesizeTrait;
 	
@@ -45,14 +45,12 @@ abstract class Object
 	 *	@return class
 	 */
 	public static function create(){
-		user_error("\Touchbase\Core\Object is a deprecated class, please use Touchbase\Core\BaseObject instead.", E_USER_DEPRECATED);
-
 		$args = func_get_args();
 
-		// Class to create should be the calling class if not Object,
+		// Class to create should be the calling class if not BaseObject,
 		// otherwise the first parameter
 		$class = get_called_class();
-		if($class == 'Object') $class = array_shift($args);
+		if($class == 'BaseObject') $class = array_shift($args);
 		
 		$newClass = new \ReflectionClass($class);
 		return $newClass->newInstanceArgs($args);

--- a/src/Core/Config/Provider/IniConfigProvider.php
+++ b/src/Core/Config/Provider/IniConfigProvider.php
@@ -31,7 +31,7 @@ namespace Touchbase\Core\Config\Provider;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class IniConfigProvider extends \Touchbase\Core\Object
+class IniConfigProvider extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	@var array

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "touchbase/touchbase-core",
 	"description": "Touchbase Core",
-	"version": "0.0.1-dev",
+	"version": "1.0.0",
 	"keywords": ["component", "core"],
 	"homepage": "http://touchbase.io",
 	"license": "MIT",

--- a/src/Data/Store.php
+++ b/src/Data/Store.php
@@ -132,7 +132,7 @@ class Store extends \ArrayObject implements StoreInterface
 	 *	@return mixed
 	 */
 	public function shift($name, $default = null){
-		$array = $this->get($name, []);
+		$array = (array)$this->get($name, []);
 		
 		if(!is_array($array)){
 			throw new \InvalidArgumentException("Property is not an array.");
@@ -168,7 +168,7 @@ class Store extends \ArrayObject implements StoreInterface
 	 *	@return mixed
 	 */
 	public function pop($name, $default = null){
-		$array = $this->get($name, []);
+		$array = (array)$this->get($name, []);
 		
 		if(!is_array($array)){
 			throw new \InvalidArgumentException("Property is not an array.");
@@ -195,7 +195,7 @@ class Store extends \ArrayObject implements StoreInterface
 		return $this->pushHelper($name, $values, false, true);
 	}
 	private function pushHelper($name, $values, $unshift = false, $unique = false){
-		$array = $this->get($name, []);
+		$array = (array)$this->get($name, []);
 		
 		foreach($values as $value){
 			if(is_array($value)){

--- a/src/Debug/Error.php
+++ b/src/Debug/Error.php
@@ -33,7 +33,7 @@ defined('TOUCHBASE') or die("Access Denied.");
 
 use Touchbase\Control\Router;
 
-class Error extends \Touchbase\Core\Object
+class Error extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	Error Codes to Text

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -31,7 +31,7 @@ namespace Touchbase\Filesystem;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-abstract class Filesystem extends \Touchbase\Core\Object {
+abstract class Filesystem extends \Touchbase\Core\BaseObject {
 	
 	/**
 	 *	@var integer

--- a/src/Security/Auth/StdAuthedUser.php
+++ b/src/Security/Auth/StdAuthedUser.php
@@ -35,7 +35,7 @@ use \Touchbase\Data\Store;
 use \Touchbase\Security\PermissionInterface;
 use \Touchbase\Security\PermissionTrait;
 
-class StdAuthedUser extends \Touchbase\Core\Object implements AuthedUserInterface, PermissionInterface
+class StdAuthedUser extends \Touchbase\Core\BaseObject implements AuthedUserInterface, PermissionInterface
 {
 	use PermissionTrait;
 	

--- a/src/Utils/Cookie.php
+++ b/src/Utils/Cookie.php
@@ -31,7 +31,7 @@ namespace Touchbase\Utils;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class Cookie extends \Touchbase\Core\Object {
+class Cookie extends \Touchbase\Core\BaseObject {
 
 	const ONE_DAY = 86400;
 	const SEVEN_DAYS = 604800;

--- a/src/Utils/Enum.php
+++ b/src/Utils/Enum.php
@@ -31,7 +31,7 @@ namespace Touchbase\Utils;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-abstract class Enum extends \Touchbase\Core\Object implements \IteratorAggregate, \JsonSerializable
+abstract class Enum extends \Touchbase\Core\BaseObject implements \IteratorAggregate, \JsonSerializable
 {
 	/**
 	 *	@var mixed

--- a/src/Utils/Sanitizer.php
+++ b/src/Utils/Sanitizer.php
@@ -33,7 +33,7 @@ defined('TOUCHBASE') or die("Access Denied.");
 
 use Touchbase\Control\Router;
 
-class Sanitizer extends \Touchbase\Core\Object
+class Sanitizer extends \Touchbase\Core\BaseObject
 {
 	
 	/**

--- a/src/Utils/SystemDetection.php
+++ b/src/Utils/SystemDetection.php
@@ -33,7 +33,7 @@ defined('TOUCHBASE') or die("Access Denied.");
 
 use Touchbase\Data\StaticStore;
 
-class SystemDetection extends \Touchbase\Core\Object
+class SystemDetection extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	Browser Information

--- a/src/Utils/Transliterator.php
+++ b/src/Utils/Transliterator.php
@@ -31,7 +31,7 @@ namespace Touchbase\Utils;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class Transliterator extends \Touchbase\Core\Object
+class Transliterator extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	@var BOOL

--- a/src/Utils/Validation.php
+++ b/src/Utils/Validation.php
@@ -31,7 +31,7 @@ namespace Touchbase\Utils;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class Validation extends \Touchbase\Core\Object implements \Countable
+class Validation extends \Touchbase\Core\BaseObject implements \Countable
 {
 	/**
 	 *	@var string

--- a/src/View/AssetStore.php
+++ b/src/View/AssetStore.php
@@ -68,11 +68,12 @@ class AssetStore extends \Touchbase\Data\Store
 	/**
 	 *	__construct
 	 *	@param \Touchbase\Core\Config\Store $config
+     *	@param array $assets
 	 */
-	public function __construct(ConfigStore $config = null){
+	public function __construct(ConfigStore $config = null, $assets = null){
 		
 		$this->setConfig($config);
-
+        parent::__construct($assets);
 	}
 		
 	/**
@@ -98,7 +99,7 @@ class AssetStore extends \Touchbase\Data\Store
 	 *	@return string
 	 */
 	public function meta(){
-		return $this->get(self::META, []);
+		return (array)$this->get(self::META, []);
 	}
 	
 	/**
@@ -131,7 +132,7 @@ class AssetStore extends \Touchbase\Data\Store
 	 *	@return string
 	 */
 	public function styles(){
-		return $this->get(self::CSS, []);
+		return (array)$this->get(self::CSS, []);
 	}
 	
 	/**
@@ -165,7 +166,7 @@ class AssetStore extends \Touchbase\Data\Store
 	 *	@return string
 	 */
 	public function scripts($head = false){
-		return $this->get(self::JS)->get($head?'head':'body', []);
+		return (array)$this->get(self::JS)->get($head?'head':'body', []);
 	}
 	
 	/**
@@ -203,7 +204,7 @@ class AssetStore extends \Touchbase\Data\Store
 	 *	@return string
 	 */
 	public function extra(){
-		return $this->get(self::OTHER, []);
+		return (array)$this->get(self::OTHER, []);
 	}
 	
 	/**
@@ -251,7 +252,7 @@ class AssetStore extends \Touchbase\Data\Store
 	 *	@return string 
 	 */
 	public function contsructTitle($reverse = false){
-		$title = $this->get("title");
+		$title = (array)$this->get("title");
 		$titleData = (!$reverse)?array_reverse($title):$title;
 		
 		return implode(" ".$this->config()->get("web")->get("title_separator", "|")." ", array_map('ucfirst', array_unique($titleData))); 

--- a/src/View/HTML.php
+++ b/src/View/HTML.php
@@ -31,7 +31,7 @@ namespace Touchbase\View;
 
 defined('TOUCHBASE') or die("Access Denied.");
 
-class HTML extends \Touchbase\Core\Object
+class HTML extends \Touchbase\Core\BaseObject
 {
 	/**
 	 *	@var BOOL

--- a/src/View/Template.php
+++ b/src/View/Template.php
@@ -34,7 +34,7 @@ defined('TOUCHBASE') or die("Access Denied.");
 use Touchbase\Filesystem\File;
 use Touchbase\Filesystem\Filesystem;
 
-class Template extends \Touchbase\Core\Object
+class Template extends \Touchbase\Core\BaseObject
 {	
 	/**
 	 *	@var \Touchbase\Control\Controller

--- a/src/View/WebpageResponse.php
+++ b/src/View/WebpageResponse.php
@@ -33,7 +33,7 @@ defined('TOUCHBASE') or die("Access Denied.");
 
 use Touchbase\Data\SessionStore;
 use Touchbase\Control\Router;
-use Touchbase\Control\WebpageController;
+use Touchbase\Control\Controller;
 use Touchbase\Filesystem\File;
 use Touchbase\Utils\SystemDetection;
 use Touchbase\Utils\DOMDocument;
@@ -46,7 +46,7 @@ class WebpageResponse extends \Touchbase\Control\HTTPResponse
 	protected $layout = "layout.tpl.php";
 	
 	/**
-	 *	@var \Touchbase\Control\WebpageController
+	 *	@var \Touchbase\Control\Controller
 	 */
 	protected $controller = null;
 	
@@ -69,11 +69,14 @@ class WebpageResponse extends \Touchbase\Control\HTTPResponse
 
 	/**
 	 *	__construct
-	 *	@param \Touchbase\Control\WebpageController $controller
+	 *	@param \Touchbase\Control\Controller $controller
+     *	@param array $assets
 	 */
-	public function __construct(WebpageController $controller){
+	public function __construct(Controller $controller, $assets = null){
 		
 		$this->controller = $controller;
+        
+        $this->_assets = AssetStore::create($this->controller->config(), $assets)->setController($this->controller);
 		
 		//Set Default Title, if available...
 		$this->assets()->pushTitle($controller->config("project")->get("name", null));
@@ -211,10 +214,6 @@ class WebpageResponse extends \Touchbase\Control\HTTPResponse
 	 *	@return \Touchbase\View\Assets
 	 */
 	public function assets(){
-		if(!$this->_assets){
-			$this->_assets = AssetStore::create($this->controller->config())->setController($this->controller);
-		}
-
 		return $this->_assets;
 	}
 	


### PR DESCRIPTION
PHP 7.2 has changed the ability to use `Object` as a class name.

This MR changes the Object to `BaseObject` - while there _probably_ isn't anyone extending from `BaseObject` externally - I've kept the class and marked it deprecated for  <PHP 7.2 users.